### PR TITLE
feat: add request logging via Postgres

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,2 @@
 - Always run `pytest {{cookiecutter.project_slug}}/tests` and ensure all tests pass after any code changes.
-- Run tests even if not explicitly requested.
+- Always add tests, keep your branch rebased instead of merged, and adhere to the commit message recommendations from cbea.ms/git-commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+- Always run `pytest {{cookiecutter.project_slug}}/tests` and ensure all tests pass after any code changes.
+- Run tests even if not explicitly requested.

--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -3,3 +3,4 @@ DEBUG=True
 MODEL_PATH={{cookiecutter.machine_learn_model_path}}
 MODEL_NAME={{cookiecutter.machine_learn_model_name}}
 MEMOIZATION_FLAG=False
+DATABASE_URL=postgresql://postgres:postgres@db:5432/app

--- a/{{cookiecutter.project_slug}}/app/core/config.py
+++ b/{{cookiecutter.project_slug}}/app/core/config.py
@@ -15,6 +15,7 @@ MAX_CONNECTIONS_COUNT: int = config("MAX_CONNECTIONS_COUNT", cast=int, default=1
 MIN_CONNECTIONS_COUNT: int = config("MIN_CONNECTIONS_COUNT", cast=int, default=10)
 SECRET_KEY: Secret = config("SECRET_KEY", cast=Secret, default="")
 MEMOIZATION_FLAG: bool = config("MEMOIZATION_FLAG", cast=bool, default=True)
+DATABASE_URL: str = config("DATABASE_URL", default="sqlite:///./app.db")
 
 PROJECT_NAME: str = config("PROJECT_NAME", default="{{cookiecutter.project_name}}")
 

--- a/{{cookiecutter.project_slug}}/app/core/events.py
+++ b/{{cookiecutter.project_slug}}/app/core/events.py
@@ -2,6 +2,8 @@ from typing import Callable
 
 import joblib
 from fastapi import FastAPI
+from core.config import MEMOIZATION_FLAG
+from db import Base, engine
 
 
 def preload_model():
@@ -15,6 +17,8 @@ def preload_model():
 
 def create_start_app_handler(app: FastAPI) -> Callable:
     def start_app() -> None:
-        preload_model()
+        if MEMOIZATION_FLAG:
+            preload_model()
+        Base.metadata.create_all(bind=engine)
 
     return start_app

--- a/{{cookiecutter.project_slug}}/app/db.py
+++ b/{{cookiecutter.project_slug}}/app/db.py
@@ -1,0 +1,8 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from core.config import DATABASE_URL
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/{{cookiecutter.project_slug}}/app/main.py
+++ b/{{cookiecutter.project_slug}}/app/main.py
@@ -7,8 +7,7 @@ from fastapi import FastAPI
 def get_application() -> FastAPI:
     application = FastAPI(title=PROJECT_NAME, debug=DEBUG, version=VERSION)
     application.include_router(api_router, prefix=API_PREFIX)
-    if MEMOIZATION_FLAG:
-        application.add_event_handler("startup", create_start_app_handler(application))
+    application.add_event_handler("startup", create_start_app_handler(application))
     return application
 
 

--- a/{{cookiecutter.project_slug}}/app/models/log.py
+++ b/{{cookiecutter.project_slug}}/app/models/log.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, Text
+
+from db import Base
+
+
+class RequestLog(Base):
+    __tablename__ = "request_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    request = Column(Text, nullable=False)
+    response = Column(Text, nullable=False)

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -14,3 +14,18 @@ services:
     volumes:
       - ./app:/app/
       - ./ml/model/:/app/ml/model/
+    depends_on:
+      - db
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
     "joblib>=1.2.0",
     "scikit-learn>=1.1.3",
     "pandas>=2.2.3",
-    "httpx>=0.27.0"
+    "httpx>=0.27.0",
+    "sqlalchemy>=2.0.0",
+    "psycopg2-binary>=2.9.0"
 ]
 
 [project.optional-dependencies]

--- a/{{cookiecutter.project_slug}}/tests/test_request_logging.py
+++ b/{{cookiecutter.project_slug}}/tests/test_request_logging.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.routes import predictor
+from db import Base
+from models.log import RequestLog
+from models.prediction import MachineLearningDataInput
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+@pytest.mark.anyio
+async def test_predict_logs_request_response(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(predictor, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(predictor, "get_prediction", lambda data: [1])
+
+    payload = {
+        "feature1": 1.0,
+        "feature2": 2.0,
+        "feature3": 3.0,
+        "feature4": 4.0,
+        "feature5": 5.0,
+    }
+    data = MachineLearningDataInput(**payload)
+
+    response = await predictor.predict(data)
+    assert response.prediction == 1.0
+
+    db = TestingSessionLocal()
+    logs = db.query(RequestLog).all()
+    assert len(logs) == 1
+    log = logs[0]
+    assert json.loads(log.request) == data.model_dump()
+    assert json.loads(log.response) == response.model_dump()
+    db.close()


### PR DESCRIPTION
## Summary
- add Postgres service to docker compose and environment
- log requests and responses to database using SQLAlchemy
- create startup event to initialize table

## Testing
- `pytest {{cookiecutter.project_slug}}/tests`

------
https://chatgpt.com/codex/tasks/task_e_68ac7960ffb88323b93d80f0d0aebfb3